### PR TITLE
Fix: Provide hosts in Hostgroup

### DIFF
--- a/host_json.go
+++ b/host_json.go
@@ -10,8 +10,8 @@ import (
 type jHost struct {
 	HostID   string      `json:"hostid"`
 	Hostname string      `json:"host"`
-	Flags    int         `json:"flags,string"`
-	Name     string      `json:"name"`
+	Flags    int         `json:"flags,string,omitempty"`
+	Name     string      `json:"name,omitempty"`
 	Macros   []HostMacro `json:"macros,omitempty"`
 	Groups   []Hostgroup `json:"groups,omitempty"`
 }

--- a/hostgroup.go
+++ b/hostgroup.go
@@ -5,25 +5,26 @@ import (
 )
 
 const (
-        // HostgroupSourceDefault indicates that a Hostgroup was created in the normal way.
-        HostgroupSourcePlain = 0
+	// HostgroupSourceDefault indicates that a Hostgroup was created in the normal way.
+	HostgroupSourcePlain = 0
 
-        // HostgroupSourceDiscovery indicates that a Hostgroup was created by Host discovery.
-        HostgroupSourceDiscovery = 4
+	// HostgroupSourceDiscovery indicates that a Hostgroup was created by Host discovery.
+	HostgroupSourceDiscovery = 4
 
-        // HostgroupInternalNo indicates that a Hostgroup is used not internally by the system.
-        HostgroupInternalNo = 0
+	// HostgroupInternalNo indicates that a Hostgroup is used not internally by the system.
+	HostgroupInternalNo = 0
 
-        // HostgroupInternalYes indicates that a Hostgroup is used internally by the system.
-        HostgroupInternalYes = 1
+	// HostgroupInternalYes indicates that a Hostgroup is used internally by the system.
+	HostgroupInternalYes = 1
 )
 
 // Hostgroup represents a Zabbix Hostgroup Object returned from the Zabbix API (see zabbix documentation).
 type Hostgroup struct {
-	GroupID		string	`json:"groupid"`
-	Name		string	`json:"name"`
-	Flags		string	`json:"flags"`
-	Internal	string	`json:"internal"`
+	GroupID  string `json:"groupid"`
+	Name     string `json:"name"`
+	Flags    string `json:"flags"`
+	Internal string `json:"internal"`
+	Hosts    []Host `json:"hosts,omitempty"`
 }
 
 // HostgroupGetParams represent the parameters for a `hostgroup.get` API call (see zabbix documentation).

--- a/hostgroup_json.go
+++ b/hostgroup_json.go
@@ -6,10 +6,11 @@ import (
 
 // jHostgroup is a private map for the Hostgroup Zabbix API object (see zabbix documentation).
 type jHostgroup struct {
-	GroupID		string	`json:"groupid"`
-	Name		string	`json:"name"`
-	Flags		string	`json:"flags"`
-	Internal	string	`json:"internal"`
+	GroupID  string  `json:"groupid"`
+	Name     string  `json:"name"`
+	Flags    string  `json:"flags"`
+	Internal string  `json:"internal"`
+	Hosts    []jHost `json:"hosts,omitempty"`
 }
 
 // Hostgroup returns a native Go Hostgroup struct mapped from the given JSON Hostgroup data.

--- a/hostgroup_json.go
+++ b/hostgroup_json.go
@@ -6,11 +6,11 @@ import (
 
 // jHostgroup is a private map for the Hostgroup Zabbix API object (see zabbix documentation).
 type jHostgroup struct {
-	GroupID  string  `json:"groupid"`
-	Name     string  `json:"name"`
-	Flags    string  `json:"flags"`
-	Internal string  `json:"internal"`
-	Hosts    []jHost `json:"hosts,omitempty"`
+	GroupID  string `json:"groupid"`
+	Name     string `json:"name"`
+	Flags    string `json:"flags"`
+	Internal string `json:"internal"`
+	Hosts    jHosts `json:"hosts,omitempty"`
 }
 
 // Hostgroup returns a native Go Hostgroup struct mapped from the given JSON Hostgroup data.
@@ -20,6 +20,14 @@ func (c *jHostgroup) Hostgroup() (*Hostgroup, error) {
 	hostgroup.Name = c.Name
 	hostgroup.Flags = c.Flags
 	hostgroup.Internal = c.Internal
+
+	if len(c.Hosts) > 0 {
+		if hosts, err := c.Hosts.Hosts(); err == nil {
+			hostgroup.Hosts = hosts
+		}
+
+	}
+
 	return hostgroup, nil
 }
 


### PR DESCRIPTION
In the current `go-zabbix` implementation, hosts list were missing in hostgroup.
I've added it.

**Zabbix request sample:**
```json
{
    "jsonrpc": "2.0",
    "method": "hostgroup.get",
    "params": {
      "output": ["groupid", "name"],
      "selectHosts": ["hostid", "host"],
      "filter": {
        "name": [
          "net-type-foo",
          "net-type-bar"
        ]
      }
    },
    "id": 1,
    "auth": "{{zbx_token}}"
}
```

**Zabbix response example:**
```json
{
    "jsonrpc": "2.0",
    "result": [
        {
            "groupid": "100100000000526",
            "name": "net-type-foo",
            "hosts": [
                {
                    "hostid": "100100000051647",
                    "host": "foo1.example.com"
                }
            ]
        },
        {
            "groupid": "100100000000701",
            "name": "net-type-bar",
            "hosts": [
                {
                    "hostid": "100100000052403",
                    "host": "bar1.example.com"
                }
            ]
        }
    ],
    "id": 1
}
```