### PR TITLE
[Feature] Session caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,33 @@ stable, fast, and allows for loose typing (using types such as`interface{}` or
 
 The package aims to have comprehensive coverage of Zabbix API methods from v1.8
 through to v3.0 without introducing limitations to the native API methods.
+
+## Example
+
+```go
+package main
+
+import (
+	"fmt"
+	"github.com/cavaliercoder/zabbix"
+)
+
+func main() {
+	// Default approach - without session caching
+	session, err := zabbix.NewSession("http://zabbix/api_jsonrpc.php", "Admin", "zabbix")
+	if err != nil {
+		panic(err)
+	}
+
+	// Use session builder with caching.
+	// You can use own cache by implementing SessionAbstractCache interface
+
+	cache := zabbix.NewSessionFileCache().SetFilePath("./zabbix_session")
+	session, err := zabbix.CreateClient("http://zabbix/api_jsonrpc.php").
+		WithCache(cache).
+		WithCredentials("Admin", "zabbix").
+		Connect()
+
+	fmt.Printf("Connected to Zabbix API v%s", session.Version())
+}
+```

--- a/cache.go
+++ b/cache.go
@@ -1,0 +1,110 @@
+package zabbix
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"time"
+)
+
+// SessionAbstractCache represents abstract Zabbix session cache backend
+type SessionAbstractCache interface {
+	// SetSessionLifetime sets lifetime of cached Zabbix session
+	SetSessionLifetime(d time.Duration)
+
+	// SaveSession saves session to a cache
+	SaveSession(session *Session) error
+
+	// HasSession checks if any valid Zabbix session has been cached and available
+	HasSession() bool
+
+	// GetSession returns cached Zabbix session
+	GetSession() (*Session, error)
+}
+
+// SessionFileCache is Zabbix session filesystem cache.
+type SessionFileCache struct {
+	filePath        string
+	sessionLifeTime time.Duration
+	filePermissions uint32
+}
+
+// SetFilePath sets Zabbix session cache file path. Default value is "./zabbix_session"
+func (c *SessionFileCache) SetFilePath(filePath string) *SessionFileCache {
+	c.filePath = filePath
+	return c
+}
+
+// SetFilePermissions sets permissions for a session file. Default value is 0655.
+func (c *SessionFileCache) SetFilePermissions(permissions uint32) *SessionFileCache {
+	c.filePermissions = permissions
+	return c
+}
+
+// SetSessionLifetime sets lifetime in seconds of cached Zabbix session. Default value is 4 hours.
+func (c *SessionFileCache) SetSessionLifetime(d time.Duration) {
+	c.sessionLifeTime = d
+}
+
+// SaveSession saves session to a cache
+func (c *SessionFileCache) SaveSession(session *Session) error {
+	serialized, err := json.Marshal(session)
+
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(c.filePath, []byte(serialized), os.FileMode(c.filePermissions))
+}
+
+// GetSession returns cached Zabbix session
+func (c *SessionFileCache) GetSession() (*Session, error) {
+	contents, err := ioutil.ReadFile(c.filePath)
+
+	if err != nil {
+		return nil, err
+	}
+
+	var session Session
+
+	if err := json.Unmarshal(contents, &session); err != nil {
+		return nil, err
+	}
+
+	return &session, err
+}
+
+// HasSession checks if any valid Zabbix session has been cached and available
+func (c *SessionFileCache) HasSession() bool {
+	stats, err := os.Stat(c.filePath)
+
+	// Try to check if session file exists and modify date
+	if os.IsNotExist(err) {
+		return false
+	}
+
+	// If file exists, check mod time as used in original portmon-sync
+	now := time.Now().Unix()
+	lastMod := stats.ModTime().Unix()
+	timeDiff := now - lastMod
+
+	// Check session TTL by time diff
+	if timeDiff > int64(c.sessionLifeTime) {
+
+		// Delete outdated session file
+		os.Remove(c.filePath)
+
+		return false
+	}
+
+	return true
+}
+
+// NewSessionFileCache creates a new instance of session file system cache
+func NewSessionFileCache() *SessionFileCache {
+	return &SessionFileCache{
+		filePath:        "./zabbix_session",
+		sessionLifeTime: 14400, // Default TTL is 4 hours
+		filePermissions: 0655,
+	}
+}

--- a/cache.go
+++ b/cache.go
@@ -20,6 +20,9 @@ type SessionAbstractCache interface {
 
 	// GetSession returns cached Zabbix session
 	GetSession() (*Session, error)
+
+	// Flush removes cached session
+	Flush() error
 }
 
 // SessionFileCache is Zabbix session filesystem cache.
@@ -98,6 +101,11 @@ func (c *SessionFileCache) HasSession() bool {
 	}
 
 	return true
+}
+
+// Flush removes a cached session
+func (c *SessionFileCache) Flush() error {
+	return os.Remove(c.filePath)
 }
 
 // NewSessionFileCache creates a new instance of session file system cache

--- a/client_builder.go
+++ b/client_builder.go
@@ -1,0 +1,58 @@
+package zabbix
+
+// ClientBuilder is Zabbix API client builder
+type ClientBuilder struct {
+	cache       SessionAbstractCache
+	hasCache    bool
+	url         string
+	credentials map[string]string
+}
+
+// WithCache sets cache for Zabbix sessions
+func (builder *ClientBuilder) WithCache(cache SessionAbstractCache) *ClientBuilder {
+	builder.cache = cache
+	builder.hasCache = true
+
+	return builder
+}
+
+// WithCredentials sets auth credentials for Zabbix API
+func (builder *ClientBuilder) WithCredentials(username string, password string) *ClientBuilder {
+	builder.credentials["username"] = username
+	builder.credentials["password"] = password
+
+	return builder
+}
+
+// Connect creates Zabbix API client and connects to the API server
+// or provides a cached server if any cache was specified
+func (builder *ClientBuilder) Connect() (session *Session, err error) {
+	// Check if any cache was defined and if it has a valid cached session
+	if builder.hasCache && builder.cache.HasSession() {
+		if session, err = builder.cache.GetSession(); err == nil {
+			return session, nil
+		}
+	}
+
+	// Otherwise - login to a Zabbix server
+	session, err = NewSession(builder.url, builder.credentials["username"], builder.credentials["password"])
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Try to cache session if any cache used
+	if builder.hasCache {
+		return session, builder.cache.SaveSession(session)
+	}
+
+	return session, err
+}
+
+// CreateClient creates a Zabbix API client builder
+func CreateClient(apiEndpoint string) *ClientBuilder {
+	return &ClientBuilder{
+		url:         apiEndpoint,
+		credentials: make(map[string]string),
+	}
+}

--- a/client_builder_test.go
+++ b/client_builder_test.go
@@ -68,7 +68,7 @@ func TestSessionCache(t *testing.T) {
 		t.Error(err)
 	}
 
-	ManualTestClientBuilder(t, cache)
+	testClientBuilder(t, cache)
 
 	if err := cache.Flush(); err != nil {
 		t.Error("failed to remove a cached session file")
@@ -92,7 +92,7 @@ func compareSessionWithMock(session *Session) error {
 }
 
 // should started by TestSessionCache
-func ManualTestClientBuilder(t *testing.T, cache SessionAbstractCache) {
+func testClientBuilder(t *testing.T, cache SessionAbstractCache) {
 	username, password, url := GetTestCredentials()
 
 	if !cache.HasSession() {

--- a/client_builder_test.go
+++ b/client_builder_test.go
@@ -1,0 +1,114 @@
+package zabbix
+
+import (
+	"fmt"
+	"io/ioutil"
+	"testing"
+)
+
+const (
+	fakeURL        = "http://localhost/api_jsonrpc.php"
+	fakeToken      = "0424bd59b807674191e7d77572075f33"
+	fakeAPIVersion = "2.0"
+)
+
+func prepareTemporaryDir(t *testing.T) (dir string, success bool) {
+	tempDir, err := ioutil.TempDir("", "zabbix-session-test")
+
+	if err != nil {
+		t.Fatalf("cannot create a temporary dir for session cache: %v", err)
+		return "", false
+	}
+
+	t.Logf("used %s directory as temporary dir", tempDir)
+
+	return "", true
+}
+
+func getTestFileCache(baseDir string) SessionAbstractCache {
+	sessionFilePath := baseDir + "/" + ".zabbix_session"
+	return NewSessionFileCache().SetFilePath(sessionFilePath)
+}
+
+func TestSessionCache(t *testing.T) {
+	// Create a fake session for r/w test
+	fakeSession := &Session{
+		URL:        fakeURL,
+		Token:      fakeToken,
+		APIVersion: fakeAPIVersion,
+	}
+
+	tempDir, success := prepareTemporaryDir(t)
+
+	if !success {
+		return
+	}
+
+	cache := getTestFileCache(tempDir)
+
+	if err := cache.SaveSession(fakeSession); err != nil {
+		t.Errorf("failed to save mock session - %v", err)
+		return
+	}
+
+	if !cache.HasSession() {
+		t.Errorf("session was saved but not detected again by cache")
+	}
+
+	// Try to get a cached session
+	cachedSession, err := cache.GetSession()
+
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	// Check session integrity
+	if err := compareSessionWithMock(cachedSession); err != nil {
+		t.Error(err)
+	}
+
+	ManualTestClientBuilder(t, cache)
+
+	if err := cache.Flush(); err != nil {
+		t.Error("failed to remove a cached session file")
+	}
+}
+
+func compareSessionWithMock(session *Session) error {
+	if session.URL != fakeURL {
+		return fmt.Errorf("Session URL '%s' is not equal to '%s'", session.URL, fakeURL)
+	}
+
+	if session.Token != fakeToken {
+		return fmt.Errorf("Session token '%s' is not equal to '%s'", session.Token, fakeToken)
+	}
+
+	if session.APIVersion != fakeAPIVersion {
+		return fmt.Errorf("Session version '%s' is not equal to '%s'", session.APIVersion, fakeAPIVersion)
+	}
+
+	return nil
+}
+
+// should started by TestSessionCache
+func ManualTestClientBuilder(t *testing.T, cache SessionAbstractCache) {
+	username, password, url := GetTestCredentials()
+
+	if !cache.HasSession() {
+		t.Errorf("ManualTestClientBuilder test requires a cached session, run TestSessionCache before running this test case")
+		return
+	}
+
+	// Try to build a session using the session builder
+	client, err := CreateClient(url).WithCache(cache).WithCredentials(username, password).Connect()
+
+	if err != nil {
+		t.Errorf("failed to create a session using cache - %s", err)
+		return
+	}
+
+	if err := compareSessionWithMock(client); err != nil {
+		t.Error(err)
+	}
+}

--- a/doc.go
+++ b/doc.go
@@ -19,10 +19,21 @@ through to v3.0 without introducing limitations to the native API methods.
 	)
 
 	func main() {
+		// Default approach - without session caching
 		session, err := zabbix.NewSession("http://zabbix/api_jsonrpc.php", "Admin", "zabbix")
 		if err != nil {
 			panic(err)
 		}
+
+		// Use session builder with caching.
+		// You can use own cache by implementing SessionAbstractCache interface
+
+		cache := zabbix.NewSessionFileCache().SetFilePath("./zabbix_session")
+		session, err := zabbix.CreateClient("http://zabbix/api_jsonrpc.php").
+			WithCache(cache).
+			WithCredentials("Admin", "zabbix").
+			Connect()
+
 
 		fmt.Printf("Connected to Zabbix API v%s", session.Version())
 	}

--- a/session_test.go
+++ b/session_test.go
@@ -7,23 +7,29 @@ import (
 
 var session *Session
 
+func GetTestCredentials() (username string, password string, url string) {
+	url = os.Getenv("ZBX_URL")
+	if url == "" {
+		url = "http://localhost:8080/api_jsonrpc.php"
+	}
+
+	username = os.Getenv("ZBX_USERNAME")
+	if username == "" {
+		username = "Admin"
+	}
+
+	password = os.Getenv("ZBX_PASSWORD")
+	if password == "" {
+		password = "zabbix"
+	}
+
+	return username, password, url
+}
+
 func GetTestSession(t *testing.T) *Session {
 	var err error
 	if session == nil {
-		url := os.Getenv("ZBX_URL")
-		if url == "" {
-			url = "http://localhost:8080/api_jsonrpc.php"
-		}
-
-		username := os.Getenv("ZBX_USERNAME")
-		if username == "" {
-			username = "Admin"
-		}
-
-		password := os.Getenv("ZBX_PASSWORD")
-		if password == "" {
-			password = "zabbix"
-		}
+		username, password, url := GetTestCredentials()
 
 		session, err = NewSession(url, username, password)
 		if err != nil {


### PR DESCRIPTION
## Changelog
* Introduced caching
  * Added built-in file cache using `SessionFileCache`
  * Session lifetime supported
  * Custom cache support by implementing `SessionAbstractCache` interface
* Added client builder as client setup facade. Used with cache.

### Checks
#### API
* [x] Abstract cache interface
* [x] File system cache
* [x] Client builder

#### Unit tests
* [x] File cache
* [x] Client builder

### Example
```go
cache := zabbix.NewSessionFileCache().SetFilePath("./zabbix_session")
session, err := zabbix.CreateClient("http://zabbix/api_jsonrpc.php").
	WithCache(cache).
	WithCredentials("Admin", "zabbix").
	Connect()


fmt.Printf("Connected to Zabbix API v%s", session.Version())
```

`SessionBuilder.Connect()` will check the cache for cached sessions. If a valid cached session exists - it will provide it, otherwize will connect to Zabbix and will save a session (if cache was provided).