### PR TITLE
[WIP] add ability to skip TLS verification in http client

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,11 @@ through to v3.0 without introducing limitations to the native API methods.
 package main
 
 import (
+	"crypto/tls"
 	"fmt"
+	"log"
+	"net/http"
+
 	"github.com/cavaliercoder/go-zabbix"
 )
 
@@ -39,12 +43,26 @@ func main() {
 
 	// Use session builder with caching.
 	// You can use own cache by implementing SessionAbstractCache interface
+	// Optionally an http.Client can be passed to the builder, allowing to skip TLS verification,
+	// pass proxy settings, etc.
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true
+			}
+		}
+	}
 
 	cache := zabbix.NewSessionFileCache().SetFilePath("./zabbix_session")
 	session, err := zabbix.CreateClient("http://zabbix/api_jsonrpc.php").
 		WithCache(cache).
+		WithHTTPClient(client).
 		WithCredentials("Admin", "zabbix").
 		Connect()
+	if err != nil {
+		log.Fatalf("%v\n", err)
+	}
 
 	fmt.Printf("Connected to Zabbix API v%s", session.Version())
 }

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	fmt.Printf("Connected to Zabbix API v%s", session.GetVersion())
 
 	// Use session builder with caching.
 	// You can use own cache by implementing SessionAbstractCache interface
@@ -64,7 +65,7 @@ func main() {
 		log.Fatalf("%v\n", err)
 	}
 
-	fmt.Printf("Connected to Zabbix API v%s", session.Version())
+	fmt.Printf("Connected to Zabbix API v%s", session.GetVersion())
 }
 ```
 

--- a/client_builder.go
+++ b/client_builder.go
@@ -40,6 +40,7 @@ func (builder *ClientBuilder) Connect() (session *Session, err error) {
 	// Check if any cache was defined and if it has a valid cached session
 	if builder.hasCache && builder.cache.HasSession() {
 		if session, err = builder.cache.GetSession(); err == nil {
+			session.client = builder.client
 			return session, nil
 		}
 	}

--- a/doc.go
+++ b/doc.go
@@ -24,6 +24,7 @@ through to v3.0 without introducing limitations to the native API methods.
 		if err != nil {
 			panic(err)
 		}
+		fmt.Printf("Connected to Zabbix API v%s", session.GetVersion())
 
 		// Use session builder with caching.
 		// You can use own cache by implementing SessionAbstractCache interface
@@ -45,7 +46,7 @@ through to v3.0 without introducing limitations to the native API methods.
 			Connect()
 
 
-		fmt.Printf("Connected to Zabbix API v%s", session.Version())
+		fmt.Printf("Connected to Zabbix API v%s", session.GetVersion())
 	}
 
 For more information see: https://github.com/cavaliercoder/go-zabbix

--- a/doc.go
+++ b/doc.go
@@ -27,10 +27,20 @@ through to v3.0 without introducing limitations to the native API methods.
 
 		// Use session builder with caching.
 		// You can use own cache by implementing SessionAbstractCache interface
+		// Optionally an http.Client can be passed to the builder, allowing to skip TLS verification,
+		// pass proxy settings, etc.
 
+		client := &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: true
+				}
+			}
+		}
 		cache := zabbix.NewSessionFileCache().SetFilePath("./zabbix_session")
 		session, err := zabbix.CreateClient("http://zabbix/api_jsonrpc.php").
 			WithCache(cache).
+			WithHTTPClient(client).
 			WithCredentials("Admin", "zabbix").
 			Connect()
 

--- a/session.go
+++ b/session.go
@@ -68,7 +68,7 @@ func (c *Session) login(username, password string) error {
 
 	res, err := c.Do(NewRequest("user.login", params))
 	if err != nil {
-		return err
+		return nil, fmt.Errorf("Error logging in to Zabbix API: %v", err)
 	}
 
 	err = res.Bind(&c.Token)

--- a/session.go
+++ b/session.go
@@ -68,7 +68,7 @@ func (c *Session) login(username, password string) error {
 
 	res, err := c.Do(NewRequest("user.login", params))
 	if err != nil {
-		return nil, fmt.Errorf("Error logging in to Zabbix API: %v", err)
+		return fmt.Errorf("Error logging in to Zabbix API: %v", err)
 	}
 
 	err = res.Bind(&c.Token)

--- a/session_test.go
+++ b/session_test.go
@@ -43,7 +43,8 @@ func GetTestSession(t *testing.T) *Session {
 func TestSession(t *testing.T) {
 	s := GetTestSession(t)
 
-	if s.Version() == "" {
+	v, err := s.GetVersion()
+	if err != nil || v == "" {
 		t.Errorf("No API version found for session")
 	}
 }


### PR DESCRIPTION
This adds the ability to skip TLS verification either when using NewSession or the client builder.

This is useful when connecting to a zabbix server that has a self signed certificate.