### PR TITLE
Added support for more host meta data

### DIFF
--- a/host.go
+++ b/host.go
@@ -10,6 +10,39 @@ const (
 
 	// HostSourceDiscovery indicates that a Host was created by Host discovery.
 	HostSourceDiscovery = 4
+
+	// HostAvailabilityUnknown Unknown availability of host, never has come online
+	HostAvailabilityUnknown = 0
+
+	// HostAvailabilityAvailable Host is available
+	HostAvailabilityAvailable = 1
+
+	// HostAvailabilityUnavailable Host is NOT available
+	HostAvailabilityUnavailable = 2
+
+	// HostInventoryModeDisabled Host inventory in disabled
+	HostInventoryModeDisabled = -1
+
+	// HostInventoryModeManual Host inventory is managed manually
+	HostInventoryModeManual = 0
+
+	// HostInventoryModeAutomatic Host inventory is managed automatically
+	HostInventoryModeAutomatic = 1
+
+	// HostTLSConnectUnencryped connect unencrypted to or from host
+	HostTLSConnectUnencryped = 1
+
+	// HostTLSConnectPSK connect with PSK to or from host
+	HostTLSConnectPSK = 2
+
+	// HostTLSConnectCertificate connect with certificate to or from host
+	HostTLSConnectCertificate = 4
+
+	// HostStatusMonitored Host is monitored
+	HostStatusMonitored = 0
+
+	// HostStatusUnmonitored Host is not monitored
+	HostStatusUnmonitored = 1
 )
 
 // Host represents a Zabbix Host returned from the Zabbix API.
@@ -34,6 +67,32 @@ type Host struct {
 
 	// Groups contains all Host Groups assigned to the Host.
 	Groups []Hostgroup
+
+	// Status of the host
+	Status int
+
+	// Availbility of host
+	Available int
+
+	// Description of host
+	Description string
+
+	// Inventory mode
+	InventoryMode int
+
+	// HostID of the proxy managing this host
+	ProxyHostID int
+
+	// How should we connect to host
+	TLSConnect int
+
+	// What type of connections we accept from host
+	TLSAccept int
+
+	TLSIssuer      string
+	TLSSubject     string
+	TLSPSKIdentity string
+	TLSPSK         string
 }
 
 // HostGetParams represent the parameters for a `host.get` API call.

--- a/host_json.go
+++ b/host_json.go
@@ -14,6 +14,19 @@ type jHost struct {
 	Name     string      `json:"name,omitempty"`
 	Macros   []HostMacro `json:"macros,omitempty"`
 	Groups   []Hostgroup `json:"groups,omitempty"`
+
+	Available     int    `json:"available,string"`
+	Description   string `json:"description,omitempty"`
+	InventoryMode int    `json:"inventory_mode"`
+	ProxyHostID   int    `json:"proxy_hostid,string"`
+	Status        int    `json:"status,string"`
+
+	TLSConnect     int    `json:"tls_connect,string"`
+	TLSAccept      int    `json:"tls_accept,string"`
+	TLSIssuer      string `json:"tls_issuer,omitempty"`
+	TLSSubject     string `json:"tls_subject,omitempty"`
+	TLSPSKIdentity string `json:"tls_psk_identity,omitempty"`
+	TLSPSK         string `json:"tls_psk,omitempty"`
 }
 
 // Host returns a native Go Host struct mapped from the given JSON Host data.
@@ -26,6 +39,17 @@ func (c *jHost) Host() (*Host, error) {
 	host.DisplayName = c.Name
 	host.Macros = c.Macros
 	host.Groups = c.Groups
+	host.Available = c.Available
+	host.Description = c.Description
+	host.InventoryMode = c.InventoryMode
+	host.Status = c.Status
+	host.ProxyHostID = c.ProxyHostID
+	host.TLSConnect = c.TLSConnect
+	host.TLSAccept = c.TLSAccept
+	host.TLSIssuer = c.TLSIssuer
+	host.TLSSubject = c.TLSSubject
+	host.TLSPSKIdentity = c.TLSPSKIdentity
+	host.TLSPSK = c.TLSPSK
 	/*
 		host.Source, err = strconv.Atoi(c.Flags)
 		if err != nil {


### PR DESCRIPTION
Added support for more meta data in the Host struct when getting a host from the API. The data is there, so why not add it to the struct? Of cause I've just implemented those I need.