### PR TITLE
Adding URL to Trigger struct

### DIFF
--- a/trigger.go
+++ b/trigger.go
@@ -97,7 +97,7 @@ type Trigger struct {
 	// LastEvent is only populated if TriggerGetParams.SelectLastEvent is set
 	LastEvent *Event
 
-	// URL is a link to the trigger in Zabbix
+	// URL is a link to the trigger graph in Zabbix
 	URL string
 }
 

--- a/trigger.go
+++ b/trigger.go
@@ -96,6 +96,9 @@ type Trigger struct {
 	//
 	// LastEvent is only populated if TriggerGetParams.SelectLastEvent is set
 	LastEvent *Event
+
+	// URL is a link to the trigger in Zabbix
+	URL string
 }
 
 // TriggerTag is trigger tag

--- a/trigger_json.go
+++ b/trigger_json.go
@@ -17,6 +17,7 @@ type jTrigger struct {
 	State       int          `json:"state,string"`
 	Tags        jTriggerTags `json:"tags"`
 	LastEvent   *jEvent      `json:"lastEvent"`
+	URL         string       `json:"url"`
 }
 
 type jTriggerTag struct {
@@ -60,6 +61,7 @@ func (c *jTrigger) Trigger() (*Trigger, error) {
 	trigger.Enabled = (c.Enabled == "1")
 	trigger.Description = c.Description
 	trigger.Expression = c.Expression
+	trigger.URL = c.URL
 
 	if c.LastEvent != nil {
 		trigger.LastEvent, err = c.LastEvent.Event()


### PR DESCRIPTION
Triggers can send back a URL field as well, but it wasn't covered in the existing structs. Since I needed it, I added it. If it should have been updated elsewhere in the code as well, I apologize, but it does seem to work at least when used to get data via GetTriggers(). 