### PR TITLE
Adding History API

### DIFF
--- a/history.go
+++ b/history.go
@@ -1,0 +1,85 @@
+package zabbix
+
+import (
+	"fmt"
+)
+
+// History represents a Zabbix History returned from the Zabbix API.
+//
+// See: https://www.zabbix.com/documentation/4.0/manual/api/reference/history/object
+type History struct {
+	// Clock is the time when that value was received.
+	Clock int
+
+	// ItemID is the ID of the related item.
+	ItemID int
+
+	// Ns is the nanoseconds when the value was received.
+	Ns int
+
+	// Value is the received value.
+	// Possible types: 0 - float; 1 - character; 2 - log; 3 - int; 4 - text;
+	Value string
+
+	// LogEventID is the Windows event log entry ID.
+	LogEventID int
+
+	// Severity is the Windows event log entry level.
+	Severity int
+
+	// Source is the Windows event log entry source.
+	Source string
+
+	// Timestamp is the Windows event log entry time.
+	Timestamp string
+}
+
+type HistoryGetParams struct {
+	GetParameters
+
+	// History object types to return
+	// Possible values: 0 - numeric float, 1 - character, 2 - log,
+	// 3 - numeric signed, 4, text
+	// Default: 3
+	History int `json:"history,omitempty"`
+
+	// HistoryIDs filters search results to histories with the given History ID's.
+	HistoryIDs []string `json:"historyids,omitempty"`
+
+	// ItemIDs filters search results to histories belong to the hosts
+	// of the given Item ID's.
+	ItemIDs []string `json:"itemids,omitempty"`
+
+	// Return only values that have been received after or at the given time.
+	TimeFrom float64 `json:"time_from,omitempty"`
+
+	// Return only values that have been received before or at the given time.
+	TimeTill float64 `json:"time_till,omitempty"`
+}
+
+// GetHistories queries the Zabbix API for Histories matching the given search
+// parameters.
+//
+// ErrEventNotFound is returned if the search result set is empty.
+// An error is returned if a transport, parsing or API error occurs.
+func (c *Session) GetHistories(params HistoryGetParams) ([]History, error) {
+	histories := make([]jHistory, 0)
+	err := c.Get("history.get", params, &histories)
+	if err != nil {
+		return nil, err
+	}
+	if len(histories) == 0 {
+		return nil, ErrNotFound
+	}
+	// map JSON Events to Go Events
+	out := make([]History, len(histories))
+	for i, jhistory := range histories {
+		history, err := jhistory.History()
+		if err != nil {
+			return nil, fmt.Errorf("Error mapping History %d in response: %v", i, err)
+		}
+		out[i] = *history
+	}
+
+	return out, nil
+}

--- a/history_json.go
+++ b/history_json.go
@@ -1,0 +1,84 @@
+package zabbix
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// jHistory is a private map for the Zabbix API History object.
+// See: https://www.zabbix.com/documentation/4.0/manual/api/reference/history/get
+type jHistory struct {
+	ItemID     string `json:"itemid"`
+	Clock      string `json:"clock"`
+	Ns         string `json:"ns"`
+	Value      string `json:"value"`
+	LogEventID string `json:"logeventid,omitempty"`
+	Severity   string `json:"severity,omitempty"`
+	Source     string `json:"source,omitempty"`
+	Timestamp  string `json:"timestamp,omitempty"`
+}
+
+// History returns a native Go History struct mapped from the given JSON History data.
+func (c *jHistory) History() (*History, error) {
+	var err error
+	history := &History{}
+
+	history.Clock, err = strconv.Atoi(c.Clock)
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing History Clock: %v", err)
+	}
+
+	history.ItemID, err = strconv.Atoi(c.ItemID)
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing History ItemID: %v", err)
+	}
+
+	history.Ns, err = strconv.Atoi(c.Ns)
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing History Ns: %v", err)
+	}
+
+	history.Value = c.Value
+
+	if c.LogEventID != "" {
+		history.LogEventID, err = strconv.Atoi(c.LogEventID)
+		if err != nil {
+			return nil, fmt.Errorf("Error parsing History LogEventID: %v", err)
+		}
+	}
+
+	if c.Severity != "" {
+		history.LogEventID, err = strconv.Atoi(c.Severity)
+		if err != nil {
+			return nil, fmt.Errorf("Error parsing History Severity: %v", err)
+		}
+	}
+
+	history.Source = c.Source
+
+	history.Timestamp = c.Timestamp
+
+	return history, err
+}
+
+// jHistories is a slice of jHistory structs.
+type jHistories []jHistory
+
+// Histories returns a native Go slice of Histories mapped from the given JSON HISTORIES
+// data.
+func (c jHistories) Histories() ([]History, error) {
+	if c != nil {
+		histories := make([]History, len(c))
+		for i, jhistory := range c {
+			history, err := jhistory.History()
+			if err != nil {
+				return nil, fmt.Errorf("Error unmarshalling History %d in JSON data: %v", i, err)
+			}
+			histories[i] = *history
+		}
+
+		return histories, nil
+	}
+
+	return nil, nil
+}


### PR DESCRIPTION
I haven't been able to test the Event Log History, since we don't use those in our environment. Also, the history.get endpoint doesn't return the ValueType like item.get does, so I left it as a string.

Usage:

```
sevenDaysAgo := time.Now().AddDate(0, 0, -7)

for _, i := range items {
	histories, err := api.GetHistories(zabbix.HistoryGetParams{
		ItemIDs:  []string{strconv.Itoa(i.ItemID)},
		TimeFrom: float64(sevenDaysAgo.Unix())})
	if len(histories) == 0 {
		fmt.Printf("%s - No history found\n", i.ItemName)
		continue
	}
        // do stuff with histories
}
```