### PR TITLE
Supporting Proxy API

### DIFF
--- a/proxies_test.go
+++ b/proxies_test.go
@@ -1,0 +1,32 @@
+package zabbix
+
+import "testing"
+
+func TestProxies(t *testing.T) {
+	session := GetTestSession(t)
+
+	params := ProxyGetParams{}
+
+	proxies, err := session.GetProxies(params)
+
+	if err != nil {
+		t.Fatalf("Error getting proxies: %v", err)
+	}
+
+	if len(proxies) == 0 {
+		t.Fatalf("No proxies found")
+	}
+
+	for i, proxy := range proxies {
+		if proxy.Hostname == "" {
+			t.Fatalf("Proxy %d returned in response body has no Hostname", i)
+		}
+		switch proxy.Status {
+		case 5, 6:
+		default:
+			t.Fatalf("Proxy %d returned in response body has invalid Proxy Status: %d", i, proxy.Status)
+		}
+	}
+
+	t.Logf("Validated %d proxies", len(proxies))
+}

--- a/proxy.go
+++ b/proxy.go
@@ -1,0 +1,136 @@
+package zabbix
+
+import (
+	"fmt"
+	"time"
+)
+
+const (
+	// ProxyStatusActiveProxy indicates that a Proxy type is active.
+	ProxyStatusActiveProxy = 5
+
+	// ProxyStatusPassiveProxy indicates that a Proxy type is passive.
+	ProxyStatusPassiveProxy = 6
+)
+
+const (
+	// ProxyTLSConnectDefault indicates that unencrypted connections to host.
+	ProxyTLSConnectDefault = 1
+
+	// ProxyTLSConnectPSK indicates that PSK encryption connections to host.
+	ProxyTLSConnectPSK = 2
+
+	// ProxyTLSConnectCert indicates that certificate encryption connections to host.
+	ProxyTLSConnectCert = 4
+)
+
+const (
+	// ProxyTLSAcceptDefault indicates that unencrypted connections from host.
+	ProxyTLSAcceptDefault = iota
+
+	// ProxyTLSAcceptPSK indicates that PSK encryption connections from host.
+	ProxyTLSAcceptPSK
+
+	// ProxyTLSAcceptCert indicates that certificate connections from host.
+	ProxyTLSAcceptCert
+)
+
+const (
+	// ProxyAutoCompressDisabled indicates that communication is not
+	// compressed between Zabbix server and proxy.
+	ProxyAutoCompressDisabled = 0
+
+	// ProxyAutoCompressEnabled indicates that communication is compressed
+	// between Zabbix server and proxy.
+	ProxyAutoCompressEnabled = 1
+)
+
+// Proxy represents a Zabbix Proxy returned from the Zabbix API
+//
+// See: https://www.zabbix.com/documentation/4.0/manual/api/reference/proxy/object
+type Proxy struct {
+	// ProxyID is the unique ID of the Proxy.
+	ProxyID string
+
+	// Hostname is the name of Proxy.
+	Hostname string
+
+	// Status is type of Proxy.
+	Status int
+
+	// Description of the Proxy.
+	Description string
+
+	// LastAccess is the UTC timestamp at which the Proxy last connected
+	// to the server.
+	LastAccess time.Time
+
+	// TLSConnect shows connection to host.
+	TLSConnect int
+
+	// TLSAccept shows connection from host.
+	TLSAccept int
+
+	// TLSIssuer is certificate issuer.
+	TLSIssuer string
+
+	// TLSSubject is certificate subject.
+	TLSSubject string
+
+	// TLSPSKIdentity is PSK identity.
+	TLSPSKIdentity string
+
+	// TLSPSK is the preshared key.
+	TLSPSK string
+
+	// ProxyAddress is IP address or DNS names of active proxy.
+	ProxyAddress string
+
+	// AutoCompress indicates if communication between Zabbix server and proxy
+	// is compressed.
+	AutoCompress int
+}
+
+// ProxyGetParams represent the parameters for a ``proxy.get API call.
+//
+// See: https://www.zabbix.com/documentation/2.2/manual/api/reference/proxy/get#parameters
+type ProxyGetParams struct {
+	GetParameters
+
+	// ProxyIDs filters search results to proxies that are members of the given
+	// Proxy IDs.
+	ProxyIDs []string `json:"proxyids,omitempty"`
+
+	SelectHosts SelectQuery `json:"selectHosts"`
+
+	SelectInterface SelectQuery `json:"selectInterface"`
+}
+
+// GetProxies queries the Zabbix API for Proxy matching the given search
+// parameters.
+//
+// ErrEventNotFound is returned if the search result set is empty.
+// An error is returned if a transport, parsing or API error occurs.
+func (c *Session) GetProxies(params ProxyGetParams) ([]Proxy, error) {
+	proxies := make([]jProxy, 0)
+	err := c.Get("proxy.get", params, &proxies)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(proxies) == 0 {
+		return nil, ErrNotFound
+	}
+
+	out := make([]Proxy, len(proxies))
+	for i, jproxy := range proxies {
+		proxy, err := jproxy.Proxy()
+		if err != nil {
+			return nil, fmt.Errorf("Error mapping Proxy %d in response: %v", i, err)
+		}
+
+		out[i] = *proxy
+	}
+
+	return out, nil
+}

--- a/proxy_json.go
+++ b/proxy_json.go
@@ -53,3 +53,25 @@ func (c *jProxy) Proxy() (*Proxy, error) {
 
 	return proxy, nil
 }
+
+type jProxies []jProxy
+
+// Proxies returns a native Go slice of Proxies mapped from the given JSON
+// Proxies data.
+func (c jProxies) Proxies() ([]Proxy, error) {
+	if c != nil {
+		proxies := make([]Proxy, len(c))
+		for i, jproxy := range c {
+			proxy, err := jproxy.Proxy()
+			if err != nil {
+				return nil, fmt.Errorf("Error unmarshalling Proxy %d in JSON data: %v", i, err)
+			}
+
+			proxies[i] = *proxy
+
+			return proxies, nil
+		}
+	}
+
+	return nil, nil
+}

--- a/proxy_json.go
+++ b/proxy_json.go
@@ -1,0 +1,55 @@
+package zabbix
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+)
+
+// jProxy is a private map for the Zabbix API Proxy object.
+// See: https://www.zabbix.com/documentation/4.0/manual/api/reference/proxy/object
+type jProxy struct {
+	ProxyID        string `json:"proxyid,omitempty"`
+	Hostname       string `json:"host"`
+	Status         int    `json:"status,string"`
+	Description    string `json:"description"`
+	LastAccess     string `json:"lastaccess"`
+	TLSConnect     int    `json:"tls_connect,string"`
+	TLSAccept      int    `json:"tls_accept,string"`
+	TLSIssuer      string `json:"tls_issuer"`
+	TLSSubject     string `json:"tls_subject"`
+	TLSPSKIdentity string `json:"tls_psk_identity"`
+	TLSPSK         string `json:"tls_psk"`
+	ProxyAddress   string `json:"proxy_address"`
+	AutoCompress   int    `json:"auto_compress,string"`
+}
+
+// Proxy returns a native Go Proxy struct mapped from the given JSON Proxy data.
+func (c *jProxy) Proxy() (*Proxy, error) {
+	var err error
+	var sec int64
+	proxy := &Proxy{}
+	proxy.ProxyID = c.ProxyID
+	proxy.Hostname = c.Hostname
+	proxy.Status = c.Status
+	proxy.Description = c.Description
+
+	// parse timestamp
+	sec, err = strconv.ParseInt(c.LastAccess, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing Proxy timestamp: %v", err)
+	}
+
+	proxy.LastAccess = time.Unix(sec, 0)
+
+	proxy.TLSConnect = c.TLSConnect
+	proxy.TLSAccept = c.TLSAccept
+	proxy.TLSIssuer = c.TLSIssuer
+	proxy.TLSSubject = c.TLSSubject
+	proxy.TLSPSKIdentity = c.TLSPSKIdentity
+	proxy.TLSPSK = c.TLSPSK
+	proxy.ProxyAddress = c.ProxyAddress
+	proxy.AutoCompress = c.AutoCompress
+
+	return proxy, nil
+}


### PR DESCRIPTION
Hello,

(This pull request is re-open https://github.com/cavaliercoder/go-zabbix/pull/33 because from branch was changed.)

I added new code to supporting proxy.get . I've tested with Zabbix 4.0.9. It works fine.

If no passive/active proxy is found in test environment, go test will be failed.

Thank you,